### PR TITLE
Fix `oneOf`

### DIFF
--- a/buildPropTypes.js
+++ b/buildPropTypes.js
@@ -13,17 +13,18 @@ const buildPropTypes = (params, propTypes, defaultProps) => {
     propTypes: propTypes || {},
     defaultProps: defaultProps || {}
   };
-  for (const param in params) {
-    switch (params[param].type) {
+  for (const key in params) {
+    const param = params[key];
+    switch (param.type) {
       case types.string:
       case types.number:
       case types.bool:
-        x.propTypes[param] = PropTypes[params[param].type];
+        x.propTypes[key] = PropTypes[param.type];
         break;
       case types.oneOf:
-        x.propTypes[param] = PropTypes.oneOf(param.oneOf);
+        x.propTypes[key] = PropTypes.oneOf(param.oneOf);
     }
-    x.defaultProps[param] = params[param].defaultValue;
+    x.defaultProps[key] = param.defaultValue;
   }
   return x;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/param-types",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/param-types",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "The Parameter Types utilities package for DECSYS Components",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- `buildPropTypes()` now correctly assigned `oneOf` arrays to `PropTypes.oneOf()`